### PR TITLE
Add test helper to wait until element is no longer on page

### DIFF
--- a/test-support/helpers/common/wait-until-not.js
+++ b/test-support/helpers/common/wait-until-not.js
@@ -5,10 +5,10 @@ import Ember from 'ember';
  *
  * @param selector
  */
-export default Ember.Test.registerAsyncHelper('waitUntil',
+export default Ember.Test.registerAsyncHelper('waitUntilNot',
 	function(app, selector) {
 		const waiter = function() {
-			return Ember.$(selector).length > 0;
+			return Ember.$(selector).length === 0;
 		};
 
 		Ember.Test.registerWaiter(waiter);


### PR DESCRIPTION
Adding a test helper to that will wait until a element has gone from the page. Specifically going to use this on the order page tests to wait until the loader on the invoice is gone instead of using waitTime().