### PR TITLE
Add a wait time to the address filler because of some timing issues

### DIFF
--- a/test-support/helpers/common/fill-in-address.js
+++ b/test-support/helpers/common/fill-in-address.js
@@ -15,5 +15,6 @@ export default Test.registerAsyncHelper('fillInAddress',
     fillIn(selector, address);
     waitUntil('.fde-form-controls-address-autocomplete-control_result-item:first');
     click('.fde-form-controls-address-autocomplete-control_result-item:first');
+    waitTime(250);
   }
 )


### PR DESCRIPTION
* Not sure why, but this seems to be still required, even with the new picker component